### PR TITLE
Utilize file guid and IE fix

### DIFF
--- a/src/BootstrapCarousel/widget/BootstrapCarousel.js
+++ b/src/BootstrapCarousel/widget/BootstrapCarousel.js
@@ -283,7 +283,11 @@
                                 //setup carouselItem
                                 carouselItem = carouselItem.split('{{first}}').join( i === 0 ? ' active' : '');
                                 if(objs[i].get(path) !== ''){
-                                  carouselItem = carouselItem.split('{{img}}').join(window.location.origin +'/file?guid='+ objs[i].get(path));
+                                    if (!window.location.origin) {
+                                    	//IE Fix
+                                        carouselItem = carouselItem.split('{{img}}').join(window.location.protocol + "//" + window.location.hostname + (window.location.port ? ':' + window.location.port: '') +'/file?guid='+ objs[i].getGuid());
+                                    }
+                                    carouselItem = carouselItem.split('{{img}}').join(window.location.origin +'/file?guid='+ objs[i].getGuid());
                                 }
                                 else{
                                   carouselItem = carouselItem.split('{{img}}').join('data:image/gif;base64,R0lGODlhAQABAIAAAFVVVQAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==');


### PR DESCRIPTION
Updated the carousel to utilize the file guid, rather than the name, which appeared to not be working (could also create issues if two files have the same filename.) Also, "window.location.origin" is not supported in IE, so an IE fix has been added.
